### PR TITLE
Debian/Ubuntu Static Release Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,26 +70,46 @@ If you want to help out, see [CONTRIBUTING](CONTRIBUTING.md) for a set of guidel
 
 The following table summarizes the tools and libraries required to build. A few of the libraries are also included in this repository (marked as "Vendored"). By default, the build uses the library installed on the system, and ignores the vendored sources. However, if no library is found installed on the system, then the vendored source will be built and used. The vendored sources are also used for statically-linked builds because distribution packages often include only shared library binaries (`.so`) but not static library archives (`.a`).
 
-| Dep            | Min. version  | Vendored | Debian/Ubuntu pkg  | Arch pkg       | Optional | Purpose        |
-| -------------- | ------------- | ---------| ------------------ | -------------- | -------- | -------------- |
-| GCC            | 4.7.3         | NO       | `build-essential`  | `base-devel`   | NO       |                |
-| CMake          | 3.0.0         | NO       | `cmake`            | `cmake`        | NO       |                |
-| pkg-config     | any           | NO       | `pkg-config`       | `base-devel`   | NO       |                |
-| Boost          | 1.58          | NO       | `libboost-all-dev` | `boost`        | NO       | C++ libraries  |
-| OpenSSL        | basically any | NO       | `libssl-dev`       | `openssl`      | NO       | sha256 sum     |
-| libzmq         | 3.0.0         | NO       | `libzmq3-dev`      | `zeromq`       | NO       | ZeroMQ library |
-| libunbound     | 1.4.16        | YES      | `libunbound-dev`   | `unbound`      | NO       | DNS resolver   |
-| libminiupnpc   | 2.0           | YES      | `libminiupnpc-dev` | `miniupnpc`    | YES      | NAT punching   |
-| libunwind      | any           | NO       | `libunwind8-dev`   | `libunwind`    | YES      | Stack traces   |
-| liblzma        | any           | NO       | `liblzma-dev`      | `xz`           | YES      | For libunwind  |
-| libreadline    | 6.3.0         | NO       | `libreadline6-dev` | `readline`     | YES      | Input editing  |
-| ldns           | 1.6.17        | NO       | `libldns-dev`      | `ldns`         | YES      | SSL toolkit    |
-| expat          | 1.1           | NO       | `libexpat1-dev`    | `expat`        | YES      | XML parsing    |
-| GTest          | 1.5           | YES      | `libgtest-dev`^    | `gtest`        | YES      | Test suite     |
-| Doxygen        | any           | NO       | `doxygen`          | `doxygen`      | YES      | Documentation  |
-| Graphviz       | any           | NO       | `graphviz`         | `graphviz`     | YES      | Documentation  |
+| Dep            | Min. version  | Vendored | Debian/Ubuntu pkg     | Arch pkg       | Optional | Purpose        |
+| -------------- | ------------- | ---------| --------------------- | -------------- | -------- | -------------- |
+| GCC            | 4.7.3         | NO       | `build-essential`     | `base-devel`   | NO       |                |
+| CMake          | 3.0.0         | NO       | `cmake`               | `cmake`        | NO       |                |
+| pkg-config     | any           | NO       | `pkg-config`          | `base-devel`   | NO       |                |
+| Boost          | 1.58          | NO       | `libboost-all-dev`    | `boost`        | NO       | C++ libraries  |
+| OpenSSL        | basically any | NO       | `libssl-dev`          | `openssl`      | NO       | sha256 sum     |
+| libzmq         | 3.0.0         | NO       | `libzmq3-dev`**^1**   | `zeromq`       | NO       | ZeroMQ library |
+| libunbound     | 1.4.16        | YES      | `libunbound-dev`      | `unbound`      | NO       | DNS resolver   |
+| libminiupnpc   | 2.0           | YES      | `libminiupnpc-dev`    | `miniupnpc`    | YES      | NAT punching   |
+| libunwind      | any           | NO       | `libunwind8-dev`      | `libunwind`    | YES      | Stack traces   |
+| liblzma        | any           | NO       | `liblzma-dev`         | `xz`           | YES      | For libunwind  |
+| libreadline    | 6.3.0         | NO       | `libreadline6-dev`    | `readline`     | YES      | Input editing  |
+| ldns           | 1.6.17        | NO       | `libldns-dev`         | `ldns`         | YES      | SSL toolkit    |
+| expat          | 1.1           | NO       | `libexpat1-dev`       | `expat`        | YES      | XML parsing    |
+| GTest          | 1.5           | YES      | `libgtest-dev`**^2**  | `gtest`        | YES      | Test suite     |
+| Doxygen        | any           | NO       | `doxygen`             | `doxygen`      | YES      | Documentation  |
+| Graphviz       | any           | NO       | `graphviz`            | `graphviz`     | YES      | Documentation  |
 
-[^] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
+[**^1**] On Debian/Ubuntu, `libzmq3-dev` may not be the correct version, and may not include libczmq3-dev/dbg when it's installed, so you may want to install cppzmq and libzmq manually with the following ordered procedures:
+  
+  zeromq/libzmq
+
+    git clone https://github.com/zeromq/libzmq.git;
+    cd libzmq;
+    mkdir build;
+    cd build;
+    cmake ..;
+    sudo make install;
+
+  zeromq/cppzmq
+
+    git clone https://github.com/zeromq/cppzmq.git;
+    cd cppzmq;
+    mkdir build;
+    cd build;
+    cmake ..;
+    sudo make install;
+
+[**^2**] On Debian/Ubuntu `libgtest-dev` only includes sources and headers. You must build the library binary manually. This can be done with the following command ```sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake . && sudo make && sudo mv libg* /usr/lib/ ```
 
 ### Build instructions
 


### PR DESCRIPTION
Updates to the dependency installation procedure to ensure static release may be built fully and correctly for Debian/Ubuntu environments. 

I've verified this as working on our build VM, but will need someone else to follow the procedure, pull down, build, and make libzmq and cppzmq, delete their build folder, and run `make release-static-linux-x86_64`, just, to see if it builds without any issues. 

1. Remember to use -j# in that make command to speed things up, relative to the number of your processors
2. `apt-get install libczmq3-dbg libczmq-dbg lib64readline6-dev:i386 cppcheck;` was also issued, but try things first without doing that, as manual installation of libzmq and cppzmq may have been all that was required 