### PR TITLE
Fix for displaying AEON seed

### DIFF
--- a/src/mnemonics/electrum-words.cpp
+++ b/src/mnemonics/electrum-words.cpp
@@ -399,6 +399,10 @@ namespace crypto
       {
         language = Language::Singleton<Language::Lojban>::instance();
       }
+      else if (language_name == "EnglishOld")
+      {
+        language = Language::Singleton<Language::EnglishOld>::instance();
+      }
       else
       {
         return false;
@@ -453,6 +457,7 @@ namespace crypto
       std::vector<Language::Base*> language_instances({
         Language::Singleton<Language::German>::instance(),
         Language::Singleton<Language::English>::instance(),
+        Language::Singleton<Language::EnglishOld>::instance(),         
         Language::Singleton<Language::Spanish>::instance(),
         Language::Singleton<Language::French>::instance(),
         Language::Singleton<Language::Italian>::instance(),


### PR DESCRIPTION
So while I was able to recover wallets using the AEON seed. When you type the "seed" command, it would display blank. The fix was to add the EnglishOld into the language list. Part of #27 